### PR TITLE
Changes in CMake files for VTK 6 compatibility

### DIFF
--- a/Tracking/CMakeLists.txt
+++ b/Tracking/CMakeLists.txt
@@ -2,7 +2,11 @@ PROJECT(TRACKING)
 
 SET(KIT Tracking)
 SET(UKIT TRACKING)
-SET(KIT_LIBS vtkHybrid vtkParallel)
+if(VTK_LIBRARIES)
+  SET(KIT_LIBS ${VTK_LIBRARIES})
+else()
+  SET(KIT_LIBS vtkHybrid vtkParallel)
+endif()
 SET(KIT_EXTRA_LIBS)
 
 SET ( Kit_HDRS

--- a/Ultrasound/CMakeLists.txt
+++ b/Ultrasound/CMakeLists.txt
@@ -2,7 +2,12 @@
 
 SET(KIT Ultrasound)
 SET(UKIT ULTRASOUND)
-SET(KIT_LIBS vtkHybrid vtkAtamaiTracking)
+
+if(VTK_LIBRARIES)
+  SET(KIT_LIBS vtkAtamaiTracking ${VTK_LIBRARIES})
+else()
+  SET(KIT_LIBS vtkHybrid vtkAtamaiTracking)
+endif()
 
 IF(VTK_MAJOR_VERSION LESS 5)
   SET(Kit_SRCS ${Kit_SRCS}


### PR DESCRIPTION
I was using AIGS with some VTK 6 code and realized it wasn't working properly. These small fixes handled the problem. I realize there are other approaches (such as  https://github.com/dgobbi/AIGS/commit/68771c87c3d3f9f4ef0fdcfdd755a85155d7b27a **Update cmake files for VTK 6** commit), but this is the one shown in the [VTK Wiki examples](http://www.vtk.org/Wiki/VTK/Examples/Cxx/Utilities/ArrayCalculator).
